### PR TITLE
[OSDEV-805] Set default tags on resources

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,7 @@ output "nat_gateway_ips" {
   value       = aws_eip.nat.*.public_ip
   description = "List of Elastic IPs associated with NAT gateways"
 }
+
+output "default_security_group_id" {
+  value = aws_vpc.default.default_security_group_id
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  default_tags {
+    tags = var.tags
+  }
+}


### PR DESCRIPTION
1. Config terraform aws provider to set default tags on all resources
2. Export value of default_security_group_id. It is necessary for setting a security group on a scheduled database anonymization task.